### PR TITLE
fix vagrant deployment 

### DIFF
--- a/setup/run-env-on-ubuntu-16.04.sh
+++ b/setup/run-env-on-ubuntu-16.04.sh
@@ -48,7 +48,7 @@ fi
 sg docker "docker run --rm hello-world" | grep "Hello from Docker!" # we use sg in order to avoid the execution of a new session to take into account the group modification thanks to https://askubuntu.com/a/469391/29219
 
 # Install Docker-Compose
-sudo -E curl -L https://github.com/docker/compose/releases/download/1.16.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+sudo -E curl -fsSL https://github.com/docker/compose/releases/download/1.16.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 ## Checking docker-compose version
 docker-compose --version | grep "docker-compose version 1.16.1, build 6d1ac21"
@@ -59,7 +59,7 @@ if [ "$1" != "--no-debattons-git-copy" ]; then
     if [ -f "$BASE_DIR/debattons-git-copy.sh" ]; then
         source "$BASE_DIR/debattons-git-copy.sh"
     else
-        curl -L "https://raw.githubusercontent.com/iorga-group/debattons/master/setup/debattons-git-copy.sh" > /tmp/setup-debattons-git-copy.sh && bash /tmp/setup-debattons-git-copy.sh
+        curl -fsSL "https://raw.githubusercontent.com/iorga-group/debattons/master/setup/debattons-git-copy.sh" > /tmp/setup-debattons-git-copy.sh && bash /tmp/setup-debattons-git-copy.sh
         rm /tmp/setup-debattons-git-copy.sh
     fi
 fi

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -22,7 +22,7 @@ Vagrant.configure("2") do |config|
 		vbox.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/vagrant", "1"]
 
 		end
-	config.vm.synced_folder "../", "/vagrant"
+	config.vm.synced_folder "../", "/vagrant", owner: "ubuntu", group: "ubuntu"
 	config.vm.network :forwarded_port, guest: 4200, host: 4200
 	config.vm.network :forwarded_port, guest: 8080, host: 8080
 	config.vm.network :forwarded_port, guest: 5000, host: 5000


### PR DESCRIPTION
**What this PR does:**
 - change `curl` options to reduce number of lines of `vagrant up` output
 - change ownership of `synced_folder` to solve following permission error:
```
default: + mkdir -p /vagrant/docker-data/conf
default: mkdir: cannot create directory ‘/vagrant/docker-data’
default: : Permission denied
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

**Special notes for your reviewer:**
Not sure this is the right way to fix this. Don't hesitate to tell me and I will look into modifying the PR accordingly.